### PR TITLE
Fix E741 warnings by renaming listener loops

### DIFF
--- a/AWS-list-resources-all-canary.py
+++ b/AWS-list-resources-all-canary.py
@@ -989,13 +989,13 @@ def get_alb_details(
 
         # Get Listeners associated with the load balancer.
         listeners = [
-            {"Port": l.get("Port"), "Protocol": l.get("Protocol")}
+            {"Port": listener.get("Port"), "Protocol": listener.get("Protocol")}
             for page in _safe_paginator(
                 elbv2_client.get_paginator("describe_listeners").paginate,
                 account=alias,
                 LoadBalancerArn=arn,
             )
-            for l in page.get("Listeners", [])
+            for listener in page.get("Listeners", [])
         ]
 
         # Get Target Groups associated with the load balancer.

--- a/AWS-list-resources-all-rc.py
+++ b/AWS-list-resources-all-rc.py
@@ -1994,13 +1994,13 @@ def get_alb_details(elbv2_client: BaseClient, alias: str) -> List[Dict[str, Any]
         for lb in chunk:
             arn = lb["LoadBalancerArn"]
             listeners = [
-                {"Port": l["Port"], "Protocol": l["Protocol"]}
+                {"Port": listener["Port"], "Protocol": listener["Protocol"]}
                 for page in _safe_paginator(
                     elbv2_client.get_paginator("describe_listeners").paginate,
                     account=alias,
                     LoadBalancerArn=arn,
                 )
-                for l in page.get("Listeners", [])
+                for listener in page.get("Listeners", [])
             ]
             tgs = _safe_aws_call(
                 elbv2_client.describe_target_groups,


### PR DESCRIPTION
## Summary
- fix ambiguous variable name warnings in listener loops
- keep `flake8` clean of E741

## Testing
- `flake8 | grep E741`

------
https://chatgpt.com/codex/tasks/task_e_68899b2b4e70833182aee985f86ab3cd