### PR TITLE
Fix slice spacing in RC script

### DIFF
--- a/AWS-list-resources-all-rc.py
+++ b/AWS-list-resources-all-rc.py
@@ -1978,7 +1978,7 @@ def get_alb_details(elbv2_client: BaseClient, alias: str) -> List[Dict[str, Any]
         )
         for lb in page.get("LoadBalancers", [])
     ]
-    for chunk in (lbs[i : i + 20] for i in range(0, len(lbs), 20)):
+    for chunk in (lbs[i:i + 20] for i in range(0, len(lbs), 20)):
         arns = [lb["LoadBalancerArn"] for lb in chunk]
         tags = _safe_aws_call(
             elbv2_client.describe_tags,


### PR DESCRIPTION
## Summary
- remove extra whitespace in AWS load balancer slice

## Testing
- `flake8 AWS-list-resources-all-rc.py | head -n 2`
- `flake8 AWS-list-resources-all-rc.py | grep -n 1981`


------
https://chatgpt.com/codex/tasks/task_e_68899fc929f883319dbeada76c489360