### PR TITLE
Use openpyxl public API for sheet ordering

### DIFF
--- a/AWS-list-resources-all-canary.py
+++ b/AWS-list-resources-all-canary.py
@@ -3734,10 +3734,15 @@ class StreamingExcelWriter:
             ws.freeze_panes = ws[f"A{header_row + 1}"]
 
         # Reorder sheets to ensure Summary is first, followed by others alphabetically
-        self.wb._sheets = sorted(
-            self.wb._sheets,
-            key=lambda s: (0, s.title) if s.title == "Summary" else (1, s.title),
+        desired_order = ["Summary"] + sorted(
+            [title for title in self.wb.sheetnames if title != "Summary"]
         )
+        for idx, title in enumerate(desired_order):
+            ws = self.wb[title]
+            current_idx = self.wb.sheetnames.index(title)
+            offset = idx - current_idx
+            if offset:
+                self.wb.move_sheet(ws, offset)
         self.wb.active = 0
 
         try:

--- a/AWS-list-resources-all-rc.py
+++ b/AWS-list-resources-all-rc.py
@@ -3931,7 +3931,12 @@ class StreamingExcelWriter:
 
     def close(self) -> None:
         ordered = sorted(self.sheets)
-        self.wb._sheets = [self.sheets[n] for n in ordered]
+        for idx, title in enumerate(ordered):
+            ws = self.sheets[title]
+            current_idx = self.wb.sheetnames.index(title)
+            offset = idx - current_idx
+            if offset:
+                self.wb.move_sheet(ws, offset)
 
         # format each data sheet
         for name in ordered:


### PR DESCRIPTION
## Summary
- in StreamingExcelWriter.close use Workbook.move_sheet to order sheets
- avoid direct access to private Workbook internals

## Testing
- `python3 -m py_compile AWS-list-resources-all-canary.py AWS-list-resources-all-rc.py`

------
https://chatgpt.com/codex/tasks/task_e_6889e2aa59008331b674fa3a4b883d43