### PR TITLE
Collect all IAM role principals

### DIFF
--- a/config.json
+++ b/config.json
@@ -187,6 +187,8 @@
             "Arn",
             "CreateDate",
             "ServicePrincipals",
+            "AccountPrincipals",
+            "FederatedPrincipals",
             "AttachedPolicies",
             "InlinePolicies",
             "AccountAlias"


### PR DESCRIPTION
## Summary
- collect principals from AWS, Service, and Federated trust policy entries
- report collected principals in IAM summary details
- expose principal lists in configuration

## Testing
- `python -m py_compile AWS-list-resources-all-canary.py AWS-list-resources-all-rc.py`
- `python -m json.tool config.json > /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_6889eb6e04188331b5d230f49da36e4f