### PR TITLE
Fix inline policy listing

### DIFF
--- a/AWS-list-resources-all-canary.py
+++ b/AWS-list-resources-all-canary.py
@@ -2043,11 +2043,14 @@ def get_iam_users_details(iam_client: BaseClient, alias: str) -> List[Dict[str, 
             )
             for p in page.get("AttachedPolicies", [])
         ]
-        user["InlinePolicies"] = _safe_aws_call(
-            iam_client.list_user_policies,
-            default={"PolicyNames": []},
+        inline_policies: List[str] = []
+        for page in _safe_paginator(
+            require_paginator(iam_client, "list_user_policies").paginate,
+            account=alias,
             UserName=user_name,
-        ).get("PolicyNames", [])
+        ):
+            inline_policies.extend(page.get("PolicyNames", []))
+        user["InlinePolicies"] = sorted(set(inline_policies))
 
         # Format timestamps
         user["CreateDate"] = to_local(
@@ -2097,11 +2100,14 @@ def get_iam_roles_details(iam_client: BaseClient, alias: str) -> List[Dict[str, 
             )
             for p in page.get("AttachedPolicies", [])
         ]
-        role["InlinePolicies"] = _safe_aws_call(
-            iam_client.list_role_policies,
-            default={"PolicyNames": []},
+        inline_policies = []
+        for page in _safe_paginator(
+            require_paginator(iam_client, "list_role_policies").paginate,
+            account=alias,
             RoleName=role_name,
-        ).get("PolicyNames", [])
+        ):
+            inline_policies.extend(page.get("PolicyNames", []))
+        role["InlinePolicies"] = sorted(set(inline_policies))
 
         # Format timestamp
         role["CreateDate"] = to_local(
@@ -2137,11 +2143,14 @@ def get_iam_groups_details(iam_client: BaseClient, alias: str) -> List[Dict[str,
             )
             for p in page.get("AttachedPolicies", [])
         ]
-        group["InlinePolicies"] = _safe_aws_call(
-            iam_client.list_group_policies,
-            default={"PolicyNames": []},
+        inline_policies = []
+        for page in _safe_paginator(
+            require_paginator(iam_client, "list_group_policies").paginate,
+            account=alias,
             GroupName=group_name,
-        ).get("PolicyNames", [])
+        ):
+            inline_policies.extend(page.get("PolicyNames", []))
+        group["InlinePolicies"] = sorted(set(inline_policies))
 
         # Format timestamp
         group["CreateDate"] = to_local(

--- a/AWS-list-resources-all-rc.py
+++ b/AWS-list-resources-all-rc.py
@@ -2457,8 +2457,16 @@ def get_iam_details(
                         UserName=user_name
                     ).get("AttachedPolicies", [])
                 ],
-                "InlinePolicies": iam_client.list_user_policies(UserName=user_name).get(
-                    "PolicyNames", []
+                "InlinePolicies": sorted(
+                    set(
+                        p
+                        for page in _safe_paginator(
+                            require_paginator(iam_client, "list_user_policies").paginate,
+                            account=alias,
+                            UserName=user_name,
+                        )
+                        for p in page.get("PolicyNames", [])
+                    )
                 ),
                 "AccountAlias": alias,
             }
@@ -2496,8 +2504,16 @@ def get_iam_details(
                         RoleName=role_name
                     ).get("AttachedPolicies", [])
                 ],
-                "InlinePolicies": iam_client.list_role_policies(RoleName=role_name).get(
-                    "PolicyNames", []
+                "InlinePolicies": sorted(
+                    set(
+                        p
+                        for page in _safe_paginator(
+                            require_paginator(iam_client, "list_role_policies").paginate,
+                            account=alias,
+                            RoleName=role_name,
+                        )
+                        for p in page.get("PolicyNames", [])
+                    )
                 ),
                 "AccountAlias": alias,
             }
@@ -2522,9 +2538,17 @@ def get_iam_details(
                         GroupName=group_name
                     ).get("AttachedPolicies", [])
                 ],
-                "InlinePolicies": iam_client.list_group_policies(
-                    GroupName=group_name
-                ).get("PolicyNames", []),
+                "InlinePolicies": sorted(
+                    set(
+                        p
+                        for page in _safe_paginator(
+                            require_paginator(iam_client, "list_group_policies").paginate,
+                            account=alias,
+                            GroupName=group_name,
+                        )
+                        for p in page.get("PolicyNames", [])
+                    )
+                ),
                 "Members": [
                     u["UserName"]
                     for u in iam_client.get_group(GroupName=group_name).get("Users", [])


### PR DESCRIPTION
## Summary
- paginate through inline policies for IAM users
- paginate through inline policies for IAM roles
- paginate through inline policies for IAM groups

## Testing
- `python -m py_compile AWS-list-resources-all-canary.py AWS-list-resources-all-rc.py`

------
https://chatgpt.com/codex/tasks/task_e_6889eb71956083319280d133e3f448fb