### PR TITLE
Fix CloudWatch Logs metric filter pagination

### DIFF
--- a/AWS-list-resources-all-canary.py
+++ b/AWS-list-resources-all-canary.py
@@ -1267,13 +1267,14 @@ def get_cloudwatch_logs_details(
         if not log_group_name:
             continue
 
-        # For each log group, get the count of associated metric filters.
-        metric_filters = _safe_aws_call(
-            logs_client.describe_metric_filters,
-            default={"metricFilters": []},
+        # For each log group, collect all associated metric filters.
+        metric_filters: List[Dict[str, Any]] = []
+        for page in _safe_paginator(
+            require_paginator(logs_client, "describe_metric_filters").paginate,
             account=alias,
             logGroupName=log_group_name,
-        )["metricFilters"]
+        ):
+            metric_filters.extend(page.get("metricFilters", []))
 
         # Build a new dictionary safely to prevent KeyErrors and ensure data integrity.
         out.append(


### PR DESCRIPTION
## Summary
- paginate through metric filters for each log group in the canary script

## Testing
- `pip install -r Dependencies/Requirements.txt`
- `python -m py_compile AWS-list-resources-all-canary.py`

------
https://chatgpt.com/codex/tasks/task_e_6889fc969b28833191e4e01d2e249fda