### PR TITLE
Use paginators for get_cost_opportunities

### DIFF
--- a/AWS-list-resources-all-canary.py
+++ b/AWS-list-resources-all-canary.py
@@ -1347,21 +1347,22 @@ def get_cost_opportunities(
     # --- 2. Unassociated Elastic IPs ---
     try:
         eip_monthly_cost = get_eip_cost(region, session)
-        for addr in ec2_client.describe_addresses().get("Addresses", []):
-            if "AssociationId" not in addr:
-                out.append(
-                    {
-                        "ResourceType": "Elastic IP",
-                        "ResourceId": addr["PublicIp"],
-                        "Reason": "Unassociated",
-                        "Details": f"AllocationId: {addr['AllocationId']}",
-                        "EstimatedMonthlySavings": (
-                            f"${eip_monthly_cost:.2f}"
-                            if eip_monthly_cost is not None
-                            else "N/A"
-                        ),
-                    }
-                )
+        for page in require_paginator(ec2_client, "describe_addresses").paginate():
+            for addr in page.get("Addresses", []):
+                if "AssociationId" not in addr:
+                    out.append(
+                        {
+                            "ResourceType": "Elastic IP",
+                            "ResourceId": addr["PublicIp"],
+                            "Reason": "Unassociated",
+                            "Details": f"AllocationId: {addr['AllocationId']}",
+                            "EstimatedMonthlySavings": (
+                                f"${eip_monthly_cost:.2f}"
+                                if eip_monthly_cost is not None
+                                else "N/A"
+                            ),
+                        }
+                    )
     except Exception as e:
         log(
             "warning",
@@ -1371,16 +1372,22 @@ def get_cost_opportunities(
 
     # --- 3. Idle Load Balancers ---
     try:
-        for lb in elbv2_client.describe_load_balancers().get("LoadBalancers", []):
-            target_groups = elbv2_client.describe_target_groups(
-                LoadBalancerArn=lb["LoadBalancerArn"]
-            ).get("TargetGroups", [])
-            is_idle = not target_groups or all(
-                not elbv2_client.describe_target_health(
-                    TargetGroupArn=tg["TargetGroupArn"]
-                ).get("TargetHealthDescriptions")
-                for tg in target_groups
-            )
+        for lb_page in require_paginator(
+            elbv2_client, "describe_load_balancers"
+        ).paginate():
+            for lb in lb_page.get("LoadBalancers", []):
+                target_groups: List[Dict[str, Any]] = []
+                for tg_page in require_paginator(
+                    elbv2_client, "describe_target_groups"
+                ).paginate(LoadBalancerArn=lb["LoadBalancerArn"]):
+                    target_groups.extend(tg_page.get("TargetGroups", []))
+
+                is_idle = not target_groups or all(
+                    not elbv2_client.describe_target_health(
+                        TargetGroupArn=tg["TargetGroupArn"]
+                    ).get("TargetHealthDescriptions")
+                    for tg in target_groups
+                )
             if is_idle:
                 out.append(
                     {


### PR DESCRIPTION
## Summary
- loop over paginated results when checking Elastic IPs
- iterate over paginated ELB and target group lists

## Testing
- `python3 -m py_compile AWS-list-resources-all-canary.py`

------
https://chatgpt.com/codex/tasks/task_e_6889fc96b27883318080e55c9c921373