### PR TITLE
Fix Savings Plan pagination

### DIFF
--- a/AWS-list-resources-all-canary.py
+++ b/AWS-list-resources-all-canary.py
@@ -2951,9 +2951,8 @@ def get_savings_plan_details(
     # The API defaults to 'active' only. We include 'retired' to get a complete history.
     savings_plan_ids = [
         sp["savingsPlanId"]
-        for sp in _safe_aws_call(
-            sp_client.describe_savings_plans, default={"savingsPlans": []}
-        ).get("savingsPlans", [])
+        for page in require_paginator(sp_client, "describe_savings_plans").paginate()
+        for sp in page.get("savingsPlans", [])
     ]
 
     if not savings_plan_ids:


### PR DESCRIPTION
## Summary
- retrieve savings plan IDs using a paginator instead of a single call

## Testing
- `python -m py_compile AWS-list-resources-all-canary.py`

------
https://chatgpt.com/codex/tasks/task_e_6889fc974d108331a6000e1fdf38056f