### PR TITLE
Use safe call for Elastic IP checks

### DIFF
--- a/AWS-list-resources-all-canary.py
+++ b/AWS-list-resources-all-canary.py
@@ -1360,22 +1360,24 @@ def get_cost_opportunities(
     # --- 2. Unassociated Elastic IPs ---
     try:
         eip_monthly_cost = get_eip_cost(region, session)
-        for page in require_paginator(ec2_client, "describe_addresses").paginate():
-            for addr in page.get("Addresses", []):
-                if "AssociationId" not in addr:
-                    out.append(
-                        {
-                            "ResourceType": "Elastic IP",
-                            "ResourceId": addr["PublicIp"],
-                            "Reason": "Unassociated",
-                            "Details": f"AllocationId: {addr['AllocationId']}",
-                            "EstimatedMonthlySavings": (
-                                f"${eip_monthly_cost:.2f}"
-                                if eip_monthly_cost is not None
-                                else "N/A"
-                            ),
-                        }
-                    )
+        addresses = _safe_aws_call(
+            ec2_client.describe_addresses, default={"Addresses": []}, account=alias
+        ).get("Addresses", [])
+        for addr in addresses:
+            if "AssociationId" not in addr:
+                out.append(
+                    {
+                        "ResourceType": "Elastic IP",
+                        "ResourceId": addr["PublicIp"],
+                        "Reason": "Unassociated",
+                        "Details": f"AllocationId: {addr['AllocationId']}",
+                        "EstimatedMonthlySavings": (
+                            f"${eip_monthly_cost:.2f}"
+                            if eip_monthly_cost is not None
+                            else "N/A"
+                        ),
+                    }
+                )
     except Exception as e:
         log(
             "warning",

--- a/AWS-list-resources-all-rc.py
+++ b/AWS-list-resources-all-rc.py
@@ -3026,7 +3026,9 @@ def get_cost_opportunities(
 
     # --- 2. Unassociated Elastic IPs ---
     try:
-        addresses = ec2_client.describe_addresses().get("Addresses", [])
+        addresses = _safe_aws_call(
+            ec2_client.describe_addresses, default={"Addresses": []}, account=alias
+        ).get("Addresses", [])
         for addr in addresses:
             if "AssociationId" not in addr:
                 out.append(


### PR DESCRIPTION
## Summary
- handle describe_addresses via `_safe_aws_call` in Canary and RC cost-opportunity scans
- iterate directly over returned addresses

## Testing
- `python -m py_compile AWS-list-resources-all-canary.py AWS-list-resources-all-rc.py`

------
https://chatgpt.com/codex/tasks/task_e_688a15762fa48331a17fb8ac10a06604