### PR TITLE
Use paginator for target group fetch

### DIFF
--- a/AWS-list-resources-all-canary.py
+++ b/AWS-list-resources-all-canary.py
@@ -1041,12 +1041,12 @@ def get_alb_details(
         # Get Target Groups associated with the load balancer.
         target_groups = [
             tg.get("TargetGroupName")
-            for tg in _safe_aws_call(
-                elbv2_client.describe_target_groups,
-                default={"TargetGroups": []},
+            for page in _safe_paginator(
+                require_paginator(elbv2_client, "describe_target_groups").paginate,
                 account=alias,
                 LoadBalancerArn=arn,
-            ).get("TargetGroups", [])
+            )
+            for tg in page.get("TargetGroups", [])
         ]
 
         # Assemble the final record for the report.


### PR DESCRIPTION
## Summary
- use `_safe_paginator` for describing target groups in ALB details

## Testing
- `python3 -m py_compile AWS-list-resources-all-canary.py`

------
https://chatgpt.com/codex/tasks/task_e_688a15903fe48331ac59fb6544a5ff35