### PR TITLE
Handle pagination for governance service checks

### DIFF
--- a/AWS-list-resources-all-canary.py
+++ b/AWS-list-resources-all-canary.py
@@ -1935,7 +1935,9 @@ def get_governance_details(
                 client.describe_hub()
                 status = "Enabled"
             elif service_name == "GuardDuty":
-                detectors = client.list_detectors().get("DetectorIds", [])
+                detectors: List[str] = []
+                for page in require_paginator(client, "list_detectors").paginate():
+                    detectors.extend(page.get("DetectorIds", []))
                 status = "Not Found"
                 if detectors:
                     status = (
@@ -1967,12 +1969,16 @@ def get_governance_details(
                 status = session_info.get("status", "UNKNOWN").title()
                 details = f"Service Role: {session_info.get('serviceRole')}"
             elif service_name == "IAM Access Analyzer":
-                analyzers = client.list_analyzers(type="ACCOUNT").get("analyzers", [])
+                analyzers: List[Dict[str, Any]] = []
+                for page in require_paginator(client, "list_analyzers").paginate(type="ACCOUNT"):
+                    analyzers.extend(page.get("analyzers", []))
                 status = "Enabled" if analyzers else "Not Enabled"
                 if analyzers:
                     details = f"Analyzers found: {[a.get('name') for a in analyzers]}"
             elif service_name == "Amazon Detective":
-                graphs = client.list_graphs().get("GraphList", [])
+                graphs: List[Dict[str, Any]] = []
+                for page in require_paginator(client, "list_graphs").paginate():
+                    graphs.extend(page.get("GraphList", []))
                 status = "Enabled" if graphs else "Not Enabled"
                 if graphs:
                     details = f"Graph ARN: {graphs[0].get('Arn')}"


### PR DESCRIPTION
## Summary
- improve GuardDuty, IAM Access Analyzer and Detective status checks
- use `require_paginator()` to gather results from all pages

## Testing
- `python3 -m py_compile AWS-list-resources-all-canary.py`


------
https://chatgpt.com/codex/tasks/task_e_688a1594eb2c83318ab500606e52096d